### PR TITLE
Bump alpine from 3.12 to 3.13.0 (#206)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG BASE="fpm-alpine"
 ###########################
 
 # full kimai source
-FROM alpine:3.12 AS git-dev
+FROM alpine:3.13.0 AS git-dev
 ARG KIMAI="1.11.1"
 # I need to do this check somewhere, we discard all but the checkout so doing here doesn't hurt
 ADD test-kimai-version.sh /test-kimai-version.sh


### PR DESCRIPTION
Bumps alpine from 3.12 to 3.13.0.

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>