### PR TITLE
chore: bump alpine from 3.13.5 to 3.14.0 (#267)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG BASE="fpm"
 ###########################
 
 # full kimai source
-FROM alpine:3.13.5 AS git-dev
+FROM alpine:3.14.0 AS git-dev
 ARG KIMAI="master"
 # I need to do this check somewhere, we discard all but the checkout so doing here doesn't hurt
 ADD assets/test-kimai-version.sh /test-kimai-version.sh


### PR DESCRIPTION
Bumps alpine from 3.13.5 to 3.14.0.

---
updated-dependencies:
- dependency-name: alpine
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>